### PR TITLE
Major ObjC Analysis Improvments

### DIFF
--- a/Core/AbstractFile.cpp
+++ b/Core/AbstractFile.cpp
@@ -21,6 +21,12 @@ uint64_t AbstractFile::readLong(uint64_t offset)
     return readLong();
 }
 
+uint64_t AbstractFile::readPointer(uint64_t offset)
+{
+	seek(offset);
+	return readPointer();
+}
+
 std::string AbstractFile::readString(size_t maxLength)
 {
     std::string result;

--- a/Core/AbstractFile.h
+++ b/Core/AbstractFile.h
@@ -51,6 +51,17 @@ public:
      */
     uint64_t readLong(uint64_t offset);
 
+	/**
+	 * Read a pointer (based on the current arch's address width) at the current offset and advance the offset
+	 * by that width.
+	 */
+	virtual uint64_t readPointer() = 0;
+
+	/**
+	 * Read a pointer (based on the current arch's address width) and advance the offset by that width.
+	 */
+	uint64_t readPointer(uint64_t address);
+
     /**
      * Read a string starting at the current reader offset. If no max length is
      * specified, a null-terminated string will be read.
@@ -77,6 +88,11 @@ public:
      * Get the offset corresponding to the end of the given section.
      */
     virtual uint64_t sectionEnd(const std::string&) const = 0;
+
+	/**
+	 * Pointer size within this current file, if known.
+	 */
+	virtual uint64_t pointerSize() const = 0;
 };
 
 }

--- a/Core/AnalysisInfo.cpp
+++ b/Core/AnalysisInfo.cpp
@@ -26,9 +26,9 @@ std::vector<std::string> MethodInfo::selectorTokens() const
     return result;
 }
 
-std::vector<std::string> MethodInfo::decodedTypeTokens() const
+std::vector<ParsedType> MethodInfo::decodedTypeTokens(BinaryNinja::Ref<BinaryNinja::Architecture> arch) const
 {
-    return TypeParser::parseEncodedType(type);
+    return TypeParser::parseEncodedType(arch, type);
 }
 
 bool MethodListInfo::hasRelativeOffsets() const

--- a/Core/AnalysisInfo.h
+++ b/Core/AnalysisInfo.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "TypeParser.h"
 
 namespace ObjectiveNinja {
 
@@ -58,7 +59,7 @@ struct MethodInfo {
     /**
      * Get the method's type as series of C-style tokens.
      */
-    std::vector<std::string> decodedTypeTokens() const;
+    std::vector<ParsedType> decodedTypeTokens(BinaryNinja::Ref<BinaryNinja::Architecture> arch) const;
 };
 
 /**
@@ -80,6 +81,30 @@ struct MethodListInfo {
     bool hasDirectSelectors() const;
 };
 
+struct IvarInfo
+{
+	uint64_t address = {};
+
+	uint32_t offset;
+	std::string name;
+	std::string types;
+
+	uint64_t offsetAddress {};
+	uint64_t nameAddress {};
+	uint64_t typesAddress {};
+	uint32_t size {};
+};
+
+/**
+ * A description of an Objective-C ivar list
+ */
+struct IvarListInfo {
+	uint64_t address {};
+
+	uint32_t count {};
+	std::vector<IvarInfo> ivars {};
+};
+
 /**
  * A description of an Objective-C class.
  */
@@ -88,11 +113,13 @@ struct ClassInfo {
 
     std::string name {};
     MethodListInfo methodList {};
+	IvarListInfo ivarList {};
 
     uint64_t listPointer {};
     uint64_t dataAddress {};
     uint64_t nameAddress {};
     uint64_t methodListAddress {};
+	uint64_t ivarListAddress {};
 };
 
 /**
@@ -103,6 +130,7 @@ struct ClassInfo {
  * analysis should be stored here, ideally in the form of other *Info structs.
  */
 struct AnalysisInfo {
+
     std::vector<CFStringInfo> cfStrings {};
 
     std::vector<SharedSelectorRefInfo> selectorRefs {};

--- a/Core/Analyzers/CFStringAnalyzer.cpp
+++ b/Core/Analyzers/CFStringAnalyzer.cpp
@@ -22,11 +22,11 @@ void CFStringAnalyzer::run()
     if (sectionStart == 0 || sectionEnd == 0)
         return;
 
-    for (auto address = sectionStart; address < sectionEnd; address += 0x20) {
+    for (auto address = sectionStart; address < sectionEnd; address += m_file->pointerSize() * 4) {
         CFStringInfo cfString;
         cfString.address = address;
-        cfString.dataAddress = arp(m_file->readLong(address + 0x10));
-        cfString.size = m_file->readLong(address + 0x18);
+        cfString.dataAddress = arp(m_file->readPointer(address + (m_file->pointerSize() * 2)));
+        cfString.size = m_file->readPointer(address + (m_file->pointerSize() * 3));
 
         m_info->cfStrings.emplace_back(cfString);
     }

--- a/Core/Analyzers/ClassAnalyzer.h
+++ b/Core/Analyzers/ClassAnalyzer.h
@@ -19,6 +19,7 @@ class ClassAnalyzer : public Analyzer {
      * Analyze a method list.
      */
     MethodListInfo analyzeMethodList(uint64_t);
+	IvarListInfo analyzeIvarList(uint64_t);
 
 public:
     ClassAnalyzer(SharedAnalysisInfo, SharedAbstractFile);

--- a/Core/Analyzers/SelectorAnalyzer.cpp
+++ b/Core/Analyzers/SelectorAnalyzer.cpp
@@ -17,15 +17,17 @@ SelectorAnalyzer::SelectorAnalyzer(SharedAnalysisInfo info,
 
 void SelectorAnalyzer::run()
 {
+
     const auto sectionStart = m_file->sectionStart("__objc_selrefs");
     const auto sectionEnd = m_file->sectionEnd("__objc_selrefs");
+
     if (sectionStart == 0 || sectionEnd == 0)
         return;
 
     for (auto address = sectionStart; address < sectionEnd; address += 0x8) {
         auto ssri = std::make_shared<SelectorRefInfo>();
         ssri->address = address;
-        ssri->rawSelector = m_file->readLong(address);
+        ssri->rawSelector = m_file->readPointer(address);
         ssri->nameAddress = arp(ssri->rawSelector);
         ssri->name = m_file->readStringAt(ssri->nameAddress);
 

--- a/Core/BinaryViewFile.cpp
+++ b/Core/BinaryViewFile.cpp
@@ -15,6 +15,16 @@ BinaryViewFile::BinaryViewFile(BinaryViewRef bv)
     : m_bv(bv)
     , m_reader(BinaryNinja::BinaryReader(bv))
 {
+	m_ptrSize = bv->GetAddressSize();
+}
+
+uint64_t BinaryViewFile::readPointer()
+{
+	if (m_ptrSize == 8)
+		return readLong();
+	else if (m_ptrSize == 4)
+		return readInt();
+	return readLong();
 }
 
 void BinaryViewFile::seek(uint64_t address)
@@ -58,6 +68,11 @@ uint64_t BinaryViewFile::sectionEnd(const std::string& name) const
         return 0;
 
     return section->GetStart() + section->GetLength();
+}
+
+uint64_t BinaryViewFile::pointerSize() const
+{
+	return m_ptrSize;
 }
 
 }

--- a/Core/BinaryViewFile.h
+++ b/Core/BinaryViewFile.h
@@ -22,6 +22,7 @@ namespace ObjectiveNinja {
  */
 class BinaryViewFile : public ObjectiveNinja::AbstractFile {
     BinaryViewRef m_bv;
+	uint64_t m_ptrSize;
     BinaryNinja::BinaryReader m_reader;
 
 public:
@@ -33,10 +34,12 @@ public:
     uint8_t readByte() override;
     uint32_t readInt() override;
     uint64_t readLong() override;
+	uint64_t readPointer() override;
 
     uint64_t imageBase() const override;
     uint64_t sectionStart(const std::string& name) const override;
     uint64_t sectionEnd(const std::string& name) const override;
+	uint64_t pointerSize() const override;
 };
 
 }

--- a/Core/TypeParser.h
+++ b/Core/TypeParser.h
@@ -9,8 +9,23 @@
 
 #include <string>
 #include <vector>
+#include <optional>
+#include <binaryninjaapi.h>
 
 namespace ObjectiveNinja {
+
+enum ParsedTypeType {
+	PredefinedType,
+	NamedType,
+	StructType
+};
+
+struct ParsedType {
+	std::string name;
+	ParsedTypeType encodedKind;
+	std::optional<BinaryNinja::Ref<BinaryNinja::Type>> type;
+	std::optional<std::string> dependency;
+};
 
 /**
  * Parser for Objective-C type strings.
@@ -20,7 +35,7 @@ public:
     /**
      * Parse an encoded type string.
      */
-    static std::vector<std::string> parseEncodedType(const std::string&);
+    static std::vector<ParsedType> parseEncodedType(BinaryNinja::Ref<BinaryNinja::Architecture> arch, const std::string&);
 };
 
 }

--- a/CustomTypes.cpp
+++ b/CustomTypes.cpp
@@ -7,80 +7,116 @@
 
 #include "CustomTypes.h"
 
-constexpr const char* AllTypesSource = R"(
-typedef void* tptr_t;
-typedef void* fptr_t;
-typedef int32_t rptr_t;
-
-typedef void* id;
-typedef char* SEL;
-
-typedef char BOOL;
-typedef int64_t NSInteger;
-typedef uint64_t NSUInteger;
-typedef double CGFloat;
-
-struct CFString {
-    const tptr_t isa;
-    uint64_t flags;
-    const tptr_t data;
-    uint64_t size;
-};
-
-struct objc_method_entry_t {
-    rptr_t name;
-    rptr_t types;
-    rptr_t imp;
-};
-
-struct objc_method_t {
-    tptr_t name;
-    tptr_t types;
-    tptr_t imp;
-};
-
-struct objc_method_list_t {
-    uint32_t obsolete;
-    uint32_t count;
-};
-
-struct objc_class_ro_t {
-    uint32_t flags;
-    uint32_t start;
-    uint32_t size;
-    uint32_t reserved;
-    const tptr_t ivar_layout;
-    const tptr_t name;
-    const tptr_t methods;
-    const tptr_t protocols;
-    const tptr_t vars;
-    const tptr_t weak_ivar_layout;
-    const tptr_t properties;
-};
-
-struct objc_class_t {
-    const tptr_t isa;
-    const tptr_t super;
-    void* cache;
-    void* vtable;
-    const fptr_t data;
-};
-)";
-
 namespace CustomTypes {
 
 using namespace BinaryNinja;
 
+std::pair<QualifiedName, Ref<Type>> finalizeStructureBuilder(Ref<BinaryView> bv, StructureBuilder sb, std::string name)
+{
+	auto classTypeStruct = sb.Finalize();
+
+	QualifiedName classTypeName(name);
+	std::string classTypeId = Type::GenerateAutoTypeId("objc", classTypeName);
+	Ref<Type> classType = Type::StructureType(classTypeStruct);
+	QualifiedName classQualName = bv->DefineType(classTypeId, classTypeName, classType);
+
+	return {classQualName, classType};
+}
+
+inline void defineTypedef(Ref<BinaryView> bv, const QualifiedName name, Ref<Type> type)
+{
+	std::string typeID = Type::GenerateAutoTypeId("objc", name);
+	bv->DefineType(typeID, name, type);
+}
+
 void defineAll(Ref<BinaryView> bv)
 {
-    std::map<QualifiedName, Ref<Type>> types, variables, functions;
-    std::string errors;
+	int addrSize = bv->GetAddressSize();
 
-    bv->GetDefaultPlatform()->ParseTypesFromSource(AllTypesSource,
-        "ObjectiveNinja.h", types, variables, functions, errors);
+	defineTypedef(bv, {"id"}, Type::PointerType(addrSize, Type::VoidType()));
+	defineTypedef(bv, {"SEL"}, Type::PointerType(addrSize, Type::IntegerType(1, false)));
 
-    for (const auto& [name, type] : types)
-        bv->DefineUserType(name, type);
+	defineTypedef(bv, {"BOOL"}, Type::IntegerType(1, false));
+	defineTypedef(bv, {"NSInteger"}, Type::IntegerType(addrSize, true));
+	defineTypedef(bv, {"NSUInteger"}, Type::IntegerType(addrSize, false));
+	defineTypedef(bv, {"CGFloat"}, Type::FloatType(addrSize));
+
+	StructureBuilder cfstringStructBuilder;
+
+	cfstringStructBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType() ), "isa");
+	cfstringStructBuilder.AddMember(Type::IntegerType(addrSize, false), "flags");
+	cfstringStructBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType() ), "data");
+	cfstringStructBuilder.AddMember(Type::IntegerType(addrSize, false), "size");
+
+	auto type = finalizeStructureBuilder(bv, cfstringStructBuilder, "CFString");
+
+	StructureBuilder methodEntry;
+
+	methodEntry.AddMember(Type::IntegerType(4, true), "name");
+	methodEntry.AddMember(Type::IntegerType(4, true), "types");
+	methodEntry.AddMember(Type::IntegerType(4, true), "imp");
+
+	type = finalizeStructureBuilder(bv, methodEntry, "objc_method_entry_t");
+
+	StructureBuilder method;
+
+	method.AddMember(Type::PointerType(addrSize, Type::VoidType()), "name");
+	method.AddMember(Type::PointerType(addrSize, Type::VoidType()), "types");
+	method.AddMember(Type::PointerType(addrSize, Type::VoidType()), "imp");
+
+	type = finalizeStructureBuilder(bv, method, "objc_method_t");
+
+	StructureBuilder methList;
+
+	methList.AddMember(Type::IntegerType(4, false), "obsolete");
+	methList.AddMember(Type::IntegerType(4, false), "count");
+
+	type = finalizeStructureBuilder(bv, methList, "objc_method_list_t");
+
+	StructureBuilder classROBuilder;
+
+	classROBuilder.AddMember(Type::IntegerType(4, false), "flags");
+	classROBuilder.AddMember(Type::IntegerType(4, false), "start");
+	classROBuilder.AddMember(Type::IntegerType(4, false), "size");
+	if (addrSize == 8)
+		classROBuilder.AddMember(Type::IntegerType(4, false), "reserved");
+	classROBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "ivar_layout");
+	classROBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "name");
+	classROBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "methods");
+	classROBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "protocols");
+	classROBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "ivars");
+	classROBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "weak_ivar_layout");
+	classROBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "properties");
+
+	type = finalizeStructureBuilder(bv, classROBuilder, "objc_class_ro_t");
+
+	StructureBuilder classBuilder;
+
+	classBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "isa");
+	classBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "super");
+	classBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "cache");
+	classBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "vtable");
+	classBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "data");
+
+	type = finalizeStructureBuilder(bv, classBuilder, "objc_class_t");
+
+	StructureBuilder ivarBuilder;
+
+	ivarBuilder.AddMember(Type::PointerType(addrSize, Type::IntegerType(4, false)), "offset");
+	ivarBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "name");
+	ivarBuilder.AddMember(Type::PointerType(addrSize, Type::VoidType()), "type");
+	ivarBuilder.AddMember(Type::IntegerType(4, false), "alignment");
+	ivarBuilder.AddMember(Type::IntegerType(4, false), "size");
+
+	type = finalizeStructureBuilder(bv, ivarBuilder, "objc_ivar_t");
+
+	StructureBuilder ivarList;
+
+	ivarList.AddMember(Type::IntegerType(4, false), "entsize");
+	ivarList.AddMember(Type::IntegerType(4, false), "count");
+
+	type = finalizeStructureBuilder(bv, ivarList, "objc_ivar_list_t");
+
 }
 
 }

--- a/CustomTypes.h
+++ b/CustomTypes.h
@@ -28,6 +28,8 @@ const std::string Method = "objc_method_t";
 const std::string MethodListEntry = "objc_method_entry_t";
 const std::string Class = "objc_class_t";
 const std::string ClassRO = "objc_class_ro_t";
+const std::string Ivar = "objc_ivar_t";
+const std::string IvarList = "objc_ivar_list_t";
 
 /**
  * Define all Objective-C-related types for a view.

--- a/InfoHandler.h
+++ b/InfoHandler.h
@@ -14,13 +14,15 @@
 using SharedAnalysisInfo = std::shared_ptr<ObjectiveNinja::AnalysisInfo>;
 
 /**
- * Utility class for applying collected AnalysisInfo to a database.
- *
- * InfoHandler is meant to be used after all analyzers intended to run on a
- * database have finished. The resulting AnalysisInfo will then be used to
- * create data variables, symbols, etc. in the database.
- */
+  * Utility class for applying collected AnalysisInfo to a database.
+  *
+  * InfoHandler is meant to be used after all analyzers intended to run on a
+  * database have finished. The resulting AnalysisInfo will then be used to
+  * create data variables, symbols, etc. in the database.
+  */
+
 class InfoHandler {
+
     /**
      * Sanitize a string by searching for series of alphanumeric characters and
      * concatenating the matches. The input string will first be truncated.
@@ -60,11 +62,13 @@ class InfoHandler {
      */
     static inline void defineReference(BinaryViewRef bv, uint64_t from, uint64_t to);
 
+	static BinaryNinja::QualifiedName createClassType(BinaryViewRef, const ObjectiveNinja::ClassInfo&, const ObjectiveNinja::IvarListInfo&);
+
     /**
      * Create a symbol and apply return/argument types for a method.
      */
     static void applyMethodType(BinaryViewRef, const ObjectiveNinja::ClassInfo&,
-        const ObjectiveNinja::MethodInfo&);
+		const BinaryNinja::QualifiedName&, const ObjectiveNinja::MethodInfo&);
 
 public:
     /**


### PR DESCRIPTION
Official changelog:

- ObjC Processing now supports armv7+thumb binaries

- Type definition speedup

- Classes now have properly defined types

- ivars now render inline as struct members to 'self'

- off-image objc_msgSend calls now properly inline the selector string

---

devlog:

AbstractFile now has an `m_ptrSize` and `readPointer()` / `readPointer(uint64_t)` / `pointerSize() -> int`. These are used to make supporting across 32/64 bit trivial. Everything that reads a pointer (so basically every single `readLong()`) now uses this.

TypeParser now returns a `ParsedType` object, which holds the name + `std::opt<Ref<Type>>` + flavor (named, struct, etc) and an unused "dependency" field, which should(?) be used later in time to do dependency resolution when we add named types.

TypeParser now requires an `Ref<Architecture>` object as arg0 since it is generating pointer class Ref<Type>s and needs to know the proper pointer size.

CustomTypes no longer uses `ParseTypesFromSource()` for several reasons. All types in the project are now defined with the official and wonderfully documented C++ api for doing so. 

All types (except for specifically the `typedefs` detailed below) via the c++ api are now registered as system types, hiding them in the Types view by default. Perhaps even the typedefs should be hidden.

New `InfoHandler::CreateClassType()` which creates and registers a structure `class_ClassName` and a `typedef struct class_ClassName* ClassName`. It then registers all of the ivars into that struct using their hard coded offsets. This results in weird looking structs in the sidebar that have plenty of gaps, so we hide them, but renders perfectly in linearview/elsewhere.

Ivar list section now has its structs processed. 

All of the struct types are now defined based on the bv's address size and adjusted based on the official objc_runtime-old.h . 

In the initializing workflow pass, we now parse through all the msgSend symbols and define their type to `void *(* const _objc_msgSend)(id self, SEL sel)` which was not at all a headache to do with the C++ api. This causes all of the un-rewritten selectors to inline their sel strings, which is an insane improvement by itself.

---

Still a lot to do, but this is hopefully a good start. This PR resolves no open issues because I am too good for that.