### PR TITLE
Swap to the Types API for parsing and defining types, instead of using ParseTypesFromString

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,9 @@ if(NOT BN_INTERNAL_BUILD)
   add_subdirectory(Vendor/BinaryNinjaAPI)
 endif()
 
-# Core library -----------------------------------------------------------------
+# Binary Ninja plugin ----------------------------------------------------------
 
-set(CORE_SOURCE
+set(PLUGIN_SOURCE
   Core/Analyzers/CFStringAnalyzer.h
   Core/Analyzers/ClassAnalyzer.h
   Core/Analyzers/SelectorAnalyzer.h
@@ -33,24 +33,7 @@ set(CORE_SOURCE
   Core/AnalysisInfo.cpp
   Core/AnalysisProvider.cpp
   Core/Analyzer.cpp
-  Core/TypeParser.cpp)
-
-add_library(objc_analysis_core STATIC ${CORE_SOURCE})
-target_compile_features(objc_analysis_core PRIVATE cxx_std_17)
-
-# Option to specify whether the core library should be built with support
-# modules for integrating with Binary Ninja. Enabled by default, but able to be
-# turned off so the core library can be built without the Binary Ninja
-# dependency; an alternative AbstractFile implementation will be needed.
-option(OAC_BN_SUPPORT "Build core library support for Binary Ninja" ON)
-if(OAC_BN_SUPPORT)
-  target_compile_definitions(objc_analysis_core PUBLIC OAC_BN_SUPPORT=1)
-  target_link_libraries(objc_analysis_core PRIVATE binaryninjaapi)
-endif()
-
-# Binary Ninja plugin ----------------------------------------------------------
-
-set(PLUGIN_SOURCE
+  Core/TypeParser.cpp
   Commands.h
   Commands.cpp
   CustomTypes.h
@@ -66,13 +49,12 @@ set(PLUGIN_SOURCE
   Workflow.cpp)
 
 add_library(workflow_objc SHARED ${PLUGIN_SOURCE})
-target_link_libraries(workflow_objc objc_analysis_core binaryninjaapi)
+target_link_libraries(workflow_objc binaryninjaapi)
 target_compile_features(workflow_objc PRIVATE cxx_std_17 c_std_99)
 
 # Library targets linking against the Binary Ninja API need to be compiled with
 # position-independent code on Linux.
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  target_compile_options(objc_analysis_core PRIVATE "-fPIC")
   target_compile_options(workflow_objc PRIVATE "-fPIC")
 endif()
 

--- a/Core/AnalysisInfo.cpp
+++ b/Core/AnalysisInfo.cpp
@@ -26,7 +26,7 @@ std::vector<std::string> MethodInfo::selectorTokens() const
     return result;
 }
 
-std::vector<std::string> MethodInfo::decodedTypeTokens() const
+std::vector<QualifiedNameOrType> MethodInfo::decodedTypeTokens() const
 {
     return TypeParser::parseEncodedType(type);
 }
@@ -41,9 +41,10 @@ bool MethodListInfo::hasDirectSelectors() const
     return (flags & FlagsMask) & 0x40000000;
 }
 
-std::string IvarInfo::decodedTypeToken() const
+QualifiedNameOrType IvarInfo::decodedTypeToken() const
 {
-    std::vector<std::string> encodedTypes = TypeParser::parseEncodedType(type);
+    std::vector<QualifiedNameOrType> encodedTypes = TypeParser::parseEncodedType(type);
+
     if (encodedTypes.size() > 0)
         return encodedTypes.front();
     else

--- a/Core/AnalysisInfo.h
+++ b/Core/AnalysisInfo.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "TypeParser.h"
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -58,7 +59,7 @@ struct MethodInfo {
     /**
      * Get the method's type as series of C-style tokens.
      */
-    std::vector<std::string> decodedTypeTokens() const;
+    std::vector<QualifiedNameOrType> decodedTypeTokens() const;
 };
 
 /**
@@ -85,8 +86,7 @@ struct MetaClassInfo;
 /**
  * A description of an Objective-C instance variable (ivar).
  */
-struct IvarInfo
-{
+struct IvarInfo {
     uint64_t address = {};
 
     uint32_t offset;
@@ -101,7 +101,7 @@ struct IvarInfo
     /**
      * Get the instance variable's type as a C-style token.
      */
-    std::string decodedTypeToken() const;
+    QualifiedNameOrType decodedTypeToken() const;
 };
 
 /**

--- a/Core/BinaryViewFile.cpp
+++ b/Core/BinaryViewFile.cpp
@@ -5,8 +5,6 @@
  * terms of the license can be found in the LICENSE.txt file.
  */
 
-#ifdef OAC_BN_SUPPORT
-
 #include "BinaryViewFile.h"
 
 namespace ObjectiveNinja {
@@ -99,5 +97,3 @@ std::string BinaryViewFile::symbolNameAtLocation(uint64_t address) const
 }
 
 }
-
-#endif

--- a/Core/BinaryViewFile.h
+++ b/Core/BinaryViewFile.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#ifdef OAC_BN_SUPPORT
-
 #include "AbstractFile.h"
 
 #include <binaryninjaapi.h>
@@ -46,5 +44,3 @@ public:
 };
 
 }
-
-#endif

--- a/Core/TypeParser.h
+++ b/Core/TypeParser.h
@@ -7,10 +7,17 @@
 
 #pragma once
 
+#include <binaryninjaapi.h>
 #include <string>
 #include <vector>
 
 namespace ObjectiveNinja {
+
+struct QualifiedNameOrType {
+    BinaryNinja::Ref<BinaryNinja::Type> type = nullptr;
+    BinaryNinja::QualifiedName name;
+    size_t ptrCount = 0;
+};
 
 /**
  * Parser for Objective-C type strings.
@@ -20,7 +27,7 @@ public:
     /**
      * Parse an encoded type string.
      */
-    static std::vector<std::string> parseEncodedType(const std::string&);
+    static std::vector<QualifiedNameOrType> parseEncodedType(const std::string&);
 };
 
 }


### PR DESCRIPTION
This PR migrates the project entirely to using the proper Type API, whereas formerly it heavily invoked the clang type parser to handle manually assembled C valid type def strings.

This PR also merges the two components of workflow_objc into a single build phase. This has zero practical effects outside of the removal of an ifdef currently. (See #36)

This comes with a heavy observed performance improvement (avg. 1.5 seconds down to avg. 0.2s on Ventura x86 Calculator.app).

Resolves #37 
Resolves #36 
Resolves #19 
Partially handles #1 (the TypeParser now returns QualifiedNames for named types. They should be cached and defined during analysis.)
Unblocks #11 
