### PR TITLE
Add back binaryninja-api submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/api"]
+	path = Vendor/BinaryNinjaAPI
+	url = https://github.com/Vector35/binaryninja-api.git


### PR DESCRIPTION
It's required to build the plugin

Fixes #43