### PR TITLE
Fixed handling of ivars with null offset pointer

### DIFF
--- a/Core/Analyzers/ClassAnalyzer.cpp
+++ b/Core/Analyzers/ClassAnalyzer.cpp
@@ -78,8 +78,9 @@ IvarListInfo ClassAnalyzer::analyzeIvarList(uint64_t address)
         ii.typeAddress = arp(m_file->readLong());
         m_file->readInt();
         ii.size = m_file->readInt();
-
-        ii.offset = m_file->readInt(ii.offsetAddress);
+        
+        if (ii.offsetAddress != 0)
+            ii.offset = m_file->readInt(ii.offsetAddress);
         ii.name = m_file->readStringAt(ii.nameAddress);
         ii.type = m_file->readStringAt(ii.typeAddress);
 


### PR DESCRIPTION
For some binaries ivars can have an offset pointer value of 0, which means attempting to read at that offset will fail and break analysis. Adding a check for a null offset pointer fixes this.