### PR TITLE
Fix inlining of `CFString` literals

### DIFF
--- a/Workflow.cpp
+++ b/Workflow.cpp
@@ -263,7 +263,10 @@ void Workflow::inlineMethodCalls(AnalysisContextRef ac)
             auto sourceExpr = insn.GetSourceExpr<LLIL_SET_REG_SSA>();
             auto addr = sourceExpr.GetValue().value;
             BinaryNinja::DataVariable var;
-            if (!bv->GetDataVariableAtAddress(addr, var) || var.type->GetString() != "struct CFString")
+            if (!bv->GetDataVariableAtAddress(addr, var))
+                return;
+            const auto varTypeString = var.type->GetString();
+            if (varTypeString != "struct CFString" && varTypeString != "struct __NSConstantString")
                 return;
 
             rewriteCFString(ssa, insnIndex);


### PR DESCRIPTION
I'm not sure when this broke but on 4.3.6550-dev (1ae64a95) inlining of `CFString` literals when viewing a Mach-O binary is not working at all. This is caused by the type of global constant `CFString`s in the `__cfstring` section being typed `__NSConstantString`. However this plugin is expecting them to be `CFString`.

This PR adds an additional check on the string's variable type to see if it is an `__NSConstantString`. There's probably a more robust solution to this but it at least gets the `CFString` inlining working again.