### PR TITLE
Add a setting to opt out of rewriting message sends with visible implementations

### DIFF
--- a/Plugin.cpp
+++ b/Plugin.cpp
@@ -42,11 +42,11 @@ BINARYNINJAPLUGIN bool CorePluginInit()
     BinaryNinja::LogRegistry::CreateLogger(PluginLoggerName);
 
     auto settings = BinaryNinja::Settings::Instance();
-    settings->RegisterSetting("core.function.objectiveC.assumeMessageSendTarget",
+    settings->RegisterSetting("core.function.objectiveC.rewriteMessageSendTarget",
         R"({
-		"title" : "Rewrite objc_msgSend calls to first visible implementation",
+		"title" : "Rewrite objc_msgSend calls in IL",
 		"type" : "boolean",
-		"default" : true,
+		"default" : false,
 		"description" : "Message sends of selectors with any visible implementation are replaced with a direct call to the first visible implementation. Note that this can produce false positives if the selector is implemented by more than one class, or shares a name with a method from a system framework."
 		})");
 

--- a/Plugin.cpp
+++ b/Plugin.cpp
@@ -41,6 +41,15 @@ BINARYNINJAPLUGIN bool CorePluginInit()
 
     BinaryNinja::LogRegistry::CreateLogger(PluginLoggerName);
 
+    auto settings = BinaryNinja::Settings::Instance();
+    settings->RegisterSetting("core.function.objectiveC.assumeMessageSendTarget",
+        R"({
+		"title" : "Rewrite objc_msgSend calls to first visible implementation",
+		"type" : "boolean",
+		"default" : true,
+		"description" : "Message sends of selectors with any visible implementation are replaced with a direct call to the first visible implementation. Note that this can produce false positives if the selector is implemented by more than one class, or shares a name with a method from a system framework."
+		})");
+
     return true;
 }
 }

--- a/Workflow.cpp
+++ b/Workflow.cpp
@@ -147,7 +147,7 @@ bool Workflow::rewriteMethodCall(LLILFunctionRef ssa, size_t insnIndex)
     ssa->GetFunction()->SetAutoCallTypeAdjustment(ssa->GetFunction()->GetArchitecture(), insn.address, {funcType, BN_DEFAULT_CONFIDENCE});
     // --
 
-    if (!BinaryNinja::Settings::Instance()->Get<bool>("core.function.objectiveC.assumeMessageSendTarget"))
+    if (!BinaryNinja::Settings::Instance()->Get<bool>("core.function.objectiveC.rewriteMessageSendTarget", bv))
         return false;
 
     // Check the analysis info for a selector reference corresponding to the


### PR DESCRIPTION
The setting is on by default to preserve the current experience. It should likely be revisited as related changes are merged.

I find this to be confusing as often as it is helpful since it picks the first implementation of the selector it sees without consideration for the type of the receiver.

This is particularly annoying if the binary being analyzed implements a method with the same name as a commonly-used method on a system type (`-description` or `-path`, for instance), or has methods with generic names (`-initWithURL:`) on many types.

Explicit cross-references from selectors to method implementations (https://github.com/Vector35/binaryninja-api/pull/6814) make it possible to see the potential implementations without rewriting the call, and an Objective-C pseudo-language (https://github.com/Vector35/binaryninja-api/pull/6807) provides a more natural representation of Objective-C message sends without these downsides.